### PR TITLE
fix: pytest 8.0.0 deprecations 

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py36,coverage-report
+envlist = py27,py36,py310,py311,coverage-report
 
 # [testenv]
 # deps = -rdev-requirements.txt
@@ -14,6 +14,18 @@ deps = -rdev-requirements.txt
 commands = coverage run --parallel --source=pytest_it -m pytest tests {posargs}
 
 [testenv:py36]
+deps = -rdev-requirements.txt
+commands = coverage run --parallel --source=pytest_it -m pytest tests {posargs}
+
+[testenv:py39]
+deps = -rdev-requirements.txt
+commands = coverage run --parallel --source=pytest_it -m pytest tests {posargs}
+
+[testenv:py310]
+deps = -rdev-requirements.txt
+commands = coverage run --parallel --source=pytest_it -m pytest tests {posargs}
+
+[testenv:py311]
 deps = -rdev-requirements.txt
 commands = coverage run --parallel --source=pytest_it -m pytest tests {posargs}
 


### PR DESCRIPTION
With the release of pytest 8, we're seeing some failures when using your very helpful plugin. I've made some changes which allow the tests to pass. Also, added Python 3.10 and 3.11 to the tox environments.

See https://github.com/wtsi-npg/npg-irods-python/actions/runs/7689630369/job/20952346214?pr=239